### PR TITLE
Pin urllib3 in line with setup.py

### DIFF
--- a/conda-forge.yml
+++ b/conda-forge.yml
@@ -4,3 +4,5 @@ github:
   tooling_branch_name: main
 conda_build:
   pkg_format: '2'
+bot:
+   inspection: hint-all

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: 5a545063449f3b9ad904644c0f251058485e29e564dedf8d4e4a7b45caf9549b
 
 build:
-  number: 0
+  number: 1
   entry_points:
     - databricks=databricks_cli.cli:cli
     - dbfs=databricks_cli.dbfs.cli:dbfs_group
@@ -31,8 +31,11 @@ requirements:
     - requests >=2.17.3
     - six >=1.10.0
     - tabulate >=0.7.7
+    - urllib3 >=1.26.7,<2.0.0
 
 test:
+  requires:
+    - pip
   imports:
     - databricks_cli
     - databricks_cli.cluster_policies
@@ -55,6 +58,7 @@ test:
   commands:
     - databricks --help
     - dbfs --help
+    - pip check
 
 about:
   home: https://github.com/databricks/databricks-cli


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

Currently, the dependencies for the conda package are out of sync with what's defined in [setup.py](https://github.com/databricks/databricks-cli/blob/dd47ce4b42cd3ad17fc74022651aa0dbbbaf1d98/setup.py#L45). This results `pip check` to fail for packages that depend on `databraicks-cli`.

More generally, I'm not sure if this pin is required in the first place (see the comment in https://github.com/databricks/databricks-cli/pull/637). This seems like something that should be (and was already) addressed in requests.

I'm also running `pip check` as part of the tests in the recipe now so that this gets flagged next time it happens.