### PR TITLE
Stamp semver build metadata into the binary

### DIFF
--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -6,11 +6,19 @@ export CGO_ENABLED=0
 
 echo "PKG_VERSION = ${PKG_VERSION}"
 
+IFS=. read -r VERSION_MAJOR VERSION_MINOR VERSION_PATCH <<< "${PKG_VERSION}"
+
+# stamp semver metadata; the Databricks Python SDK feature-gates on it and treats 0.0.0 as a dev build
 go mod vendor
 go build \
     -trimpath \
     -mod vendor \
-    -ldflags "-X github.com/databricks/cli/internal/build.buildVersion=${PKG_VERSION}" \
+    -ldflags "\
+-X github.com/databricks/cli/internal/build.buildVersion=${PKG_VERSION} \
+-X github.com/databricks/cli/internal/build.buildMajor=${VERSION_MAJOR} \
+-X github.com/databricks/cli/internal/build.buildMinor=${VERSION_MINOR} \
+-X github.com/databricks/cli/internal/build.buildPatch=${VERSION_PATCH} \
+-X github.com/databricks/cli/internal/build.buildSummary=v${PKG_VERSION}" \
     -o "${BINARY_FILEPATH}"
 
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -32,7 +32,7 @@ test:
     - databricks --help
     - databricks --version | rg {{ version }}
     # semver metadata must be stamped, not the 0.0.0 dev-build defaults
-    - databricks version --output json | rg "Major.: {{ version.split('.')[0] }},"
+    - 'databricks version --output json | rg "Major.: {{ version.split(".")[0] }},"'
     - databricks version --output json | rg v{{ version }}
 
 about:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -14,7 +14,7 @@ source:
 
 
 build:
-  number: 0
+  number: 1
   script_env:
     - BINARY_FILEPATH={{ PREFIX }}/bin/databricks      # [not win]
     - BINARY_FILEPATH={{ PREFIX }}/bin/databricks.exe  # [win]
@@ -31,6 +31,9 @@ test:
   commands:
     - databricks --help
     - databricks --version | rg {{ version }}
+    # semver metadata must be stamped, not the 0.0.0 dev-build defaults
+    - databricks version --output json | rg "Major.: {{ version.split('.')[0] }},"
+    - databricks version --output json | rg v{{ version }}
 
 about:
   summary: A command line interface for Databricks


### PR DESCRIPTION
The recipe currently injects only `buildVersion` via ldflags, leaving the other version variables in `internal/build` at their Go-source defaults. The built binary therefore reports `Major/Minor/Patch = 0` and `Summary = "v0.0.0"` in `databricks version --output json`, even though `--version` looks correct.

This is not cosmetic: the [Databricks Python SDK feature-gates on those numeric fields](https://github.com/databricks/databricks-sdk-py/blob/main/databricks/sdk/credentials_provider.py) — it treats `(0,0,0)` as an unversioned dev build and disables `--profile`-based token retrieval, which breaks `WorkspaceClient(profile=...)` authentication (keychain-backed OAuth) for conda-forge users while the official release binaries work. This is what the SDK logs when it invokes a conda-forge build (verified on 0.271.0, 1.5.0, and 1.8.0):

```
INFO: Databricks CLI v0.0.0-dev is a development build; feature detection will use conservative fallbacks. Rebuild the CLI with an explicit version to enable capability-based flag selection.
WARNING: Could not confirm --profile support for Databricks CLI v0.0.0-dev (requires >= v0.207.1). Falling back to --host.
WARNING: Could not confirm --force-refresh support for Databricks CLI v0.0.0-dev (requires >= v0.296.0). The CLI's token cache may provide stale tokens.
```

Upstream's goreleaser build stamps all of these variables; this PR brings the recipe in line for the semver-derived subset (`buildMajor`, `buildMinor`, `buildPatch`, `buildSummary`), which need nothing but `PKG_VERSION`. Git-derived fields (branch/commit) are left at defaults since the build is from a source tarball.

Also adds test commands asserting the stamped metadata, so a regression fails CI. Since `bld.bat` delegates to `build.sh` under MSYS2, the single script change covers all platforms.

**Checklist:**
- [x] Used a personal fork of the feedstock to propose changes
- [x] Bumped the build number (if the version is unchanged)
- [ ] Reset the build number to `0` (if the version changed) — N/A
- [ ] Re-rendered with the latest `conda-smithy` — happy to comment `@conda-forge-admin, please rerender` if wanted
- [x] Ensured the license file is being packaged — unchanged